### PR TITLE
Fix render_readme when man/figures/ doesn't exist

### DIFF
--- a/.github/workflows/render_readme.yml
+++ b/.github/workflows/render_readme.yml
@@ -44,6 +44,6 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add README.md man/figures/
+          git add README.md man/figures/*
           git diff-index --quiet HEAD || git commit -m "Automatic readme update"
           git push origin || echo "No changes to push"


### PR DESCRIPTION
The change done in #12 causes issue when `man/figures/` doesn't exist. See https://github.com/epiverse-trace/etdev/actions/runs/3629893234/jobs/6122615621.