### PR TITLE
Add new _R_CHECK_LENGTH_COLON variable

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -57,6 +57,8 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      # Exists since R 4.3.0 but `false` by default
+      _R_CHECK_LENGTH_COLON_: true
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
to make

```r
start <- 1:2
start:10
```

an error instead of a warning