### PR TITLE
Do not render README in a temp dir

### DIFF
--- a/.github/workflows/render_readme.yml
+++ b/.github/workflows/render_readme.yml
@@ -42,16 +42,19 @@ jobs:
  
       - name: Compile the readme
         run: |
-          tf <- tempfile(fileext = ".Rmd")
           writeLines(
             knitr::knit_expand(
-              "README.Rmd", 
-              packagename = read.dcf("DESCRIPTION", "Package"), 
+              "README.Rmd",
+              packagename = read.dcf("DESCRIPTION", "Package"),
               gh_repo = Sys.getenv("GITHUB_REPOSITORY")
-            ), 
-            tf
+            ),
+            "README_expanded.Rmd"
           )
-          rmarkdown::render(tf, output_file = "README.md", output_dir = ".")
+          rmarkdown::render(
+            "README_expanded.Rmd",
+            output_file = "README.md",
+            output_dir = "."
+          )
         shell: Rscript {0}
         
       - name: Commit files


### PR DESCRIPTION
This causes issues for READMEs that include external local files, such as images, bibliography, etc.