### PR TITLE
Disable indentation_linter

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -6,6 +6,7 @@ linters: linters_with_tags(
     extraction_operator_linter = NULL,
     todo_comment_linter = NULL,
     function_argument_linter = NULL,
+    indentation_linter = NULL, # unstable as of lintr 3.1.0
     # Use minimum R declared in DESCRIPTION or fall back to current R version.
     # Install etdev package from https://github.com/epiverse-trace/etdev
     backport_linter(if (length(x <- etdev::extract_min_r_version())) x else getRversion())


### PR DESCRIPTION
As of lintr 3.1.0, this specific linter is unstable and will generate false-positives and conflicts will styler.