### PR TITLE
Ignore bibtex files in repo language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bib -linguist-detectable


### PR DESCRIPTION
To avoid having repos classified at TeX when we use long bib files.

More info: https://devguide.ropensci.org/grooming.html#github-linguist