### PR TITLE
Add RcppExports.R to lintr exclusion list

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -28,5 +28,8 @@ exclusions: list(
     "data-raw" = list(
       missing_package_linter = Inf,
       namespace_linter = Inf
-    )
+    ),
+    # RcppExports.R is auto-generated and will not pass many linters. In
+    # particular, it can create very long lines.
+    "R/RcppExports.R"
   )


### PR DESCRIPTION
Should fix https://github.com/epiverse-trace/.github/issues/17.

@pratikunterwegs @bahadzie could you give it a try please?