### PR TITLE
Remove contribute section of design vignette

### DIFF
--- a/vignettes/design-principles.Rmd
+++ b/vignettes/design-principles.Rmd
@@ -42,7 +42,3 @@ None of the sections are required, feel free to remove any sections not relevant
 ## Development journey
 
 <  If the package has undergone any large refactoring this section can be used to explain the changes. >
-
-## Contribute
-
-< Any additional information for a developer to help them contribute to the package, do not repeat information from the [package contributing guide](https://github.com/epiverse-trace/.github/blob/main/CONTRIBUTING.md). >


### PR DESCRIPTION
This PR removes Contribute section of `design-principles.Rmd` as suggested in #97.