### PR TITLE
Test alternative approach to not trigger on releases

### DIFF
--- a/.github/workflows/render_readme.yml
+++ b/.github/workflows/render_readme.yml
@@ -26,7 +26,8 @@ name: render-readme
 on:
   workflow_dispatch:
   push:
-    tags-ignore:
+    branches:
+      # This may seem like a no-op but it prevents triggering on tags
       - '*'
     paths:
       - 'README.Rmd'

--- a/.github/workflows/render_readme.yml
+++ b/.github/workflows/render_readme.yml
@@ -28,7 +28,8 @@ on:
   push:
     branches:
       # This may seem like a no-op but it prevents triggering on tags
-      - '*'
+      # We use '**' rather '*' to accomodate names like 'dev/branch-1'
+      - '**'
     paths:
       - 'README.Rmd'
       - '.github/workflows/render_readme.yml'

--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -5,7 +5,8 @@
 # For customizing the triggers, visit https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 on:
   push:
-    tags-ignore:
+    branches:
+      # This may seem like a no-op but it prevents triggering on tags
       - '*'
     paths:
       - DESCRIPTION

--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -6,8 +6,9 @@
 on:
   push:
     branches:
-      # This may seem like a no-op but it prevents triggering on tags
-      - '*'
+      # This may seem like a no-op but it prevents triggering on tags.
+      # We use '**' rather '*' to accomodate names like 'dev/branch-1'
+      - '**'
     paths:
       - DESCRIPTION
       - inst/CITATION


### PR DESCRIPTION
Should fix #108 

Tested in https://github.com/epiverse-trace/testpkg/actions/workflows/render_readme.yml. It is indeed triggered by pushes by not by releases.