### PR TITLE
Use correct package name in license files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
 YEAR: 2022
-COPYRIGHT HOLDER: readepi authors
+COPYRIGHT HOLDER: packagetemplate authors

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2022 readepi authors
+Copyright (c) 2022 packagetemplate authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The license files (`LICENSE` and `LICENSE.md`) were stating the copyright to the {readepi} authors. This PR updates the license files to specify the copyright holder is the {packagetemplate} authors. 

I initially noticed this when updating a package that derived from {packagetemplate}. I had replaced all instances of "packagetemplate" but had missed these as I did not do a full package search of "readepi". This PR removes the last instances of "readepi" from {packagetemplate}.