### PR TITLE
Add Chris as contributor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,9 @@ Authors@R: c(
     person("Karim", "Mané", , "karim.mane@lshtm.ac.uk", role = "aut",
            comment = c(ORCID = "0000-0002-9892-2999")),
     person("Jaime A.", "Pavlich-Mariscal", , "jpavlich@javeriana.edu.co", role = "ctb",
-           comment = c(ORCID = "https://orcid.org/0000-0002-3892-6680"))
+           comment = c(ORCID = "https://orcid.org/0000-0002-3892-6680")),
+    person("Chris", "Hartgerink", , "chris@data.org", role = "ctb",
+           comment = c(ORCID = "https://orcid.org/0000-0003-1050-6809"))
   )
 Description: Your package description. It must end with a period (".") and
     include relevant bibliographical references if applicable, using the


### PR DESCRIPTION
This PR adds myself as a contributor into the template, for easy inclusion (and removal) upon using the template.

I added myself as contributor (`ctb`) but if this should be author (`author`) let me know and I'll update accordingly.