### PR TITLE
Remove ORCID domains from `DESCRIPTION`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,19 +3,19 @@ Title: Your Package Title in Titlecase
 Version: 0.0.1
 Authors@R: c(
     person("James M.", "Azam", , "james.azam@lshtm.ac.uk", role = "aut",
-           comment = c(ORCID = "https://orcid.org/0000-0001-5782-7330")),
+           comment = c(ORCID = "0000-0001-5782-7330")),
     person("Hugo", "Gruson", , "hugo@data.org", role = c("aut", "cre"),
-           comment = c(ORCID = "https://orcid.org/0000-0002-4094-1476")),
+           comment = c(ORCID = "0000-0002-4094-1476")),
     person("Pratik", "Gupte", , "pratik.gupte@lshtm.ac.uk", role = "aut",
-           comment = c(ORCID = "https://orcid.org/0000-0001-5294-7819")),
+           comment = c(ORCID = "0000-0001-5294-7819")),
     person("Joshua W.", "Lambert", , "joshua.lambert@lshtm.ac.uk", role = "aut",
            comment = c(ORCID = "0000-0001-5218-3046")),
     person("Karim", "Mané", , "karim.mane@lshtm.ac.uk", role = "aut",
            comment = c(ORCID = "0000-0002-9892-2999")),
     person("Jaime A.", "Pavlich-Mariscal", , "jpavlich@javeriana.edu.co", role = "ctb",
-           comment = c(ORCID = "https://orcid.org/0000-0002-3892-6680")),
+           comment = c(ORCID = "0000-0002-3892-6680")),
     person("Chris", "Hartgerink", , "chris@data.org", role = "ctb",
-           comment = c(ORCID = "https://orcid.org/0000-0003-1050-6809"))
+           comment = c(ORCID = "0000-0003-1050-6809"))
   )
 Description: Your package description. It must end with a period (".") and
     include relevant bibliographical references if applicable, using the


### PR DESCRIPTION
Hi 👋 I noticed while reviewing the `vaccineff` package that there were issues with the URLs from the website. More specifically, the URLs look like this: `https://orcid.org/https://orcid.org/0000-0002-8165-3198` (see also https://github.com/epiverse-trace/vaccineff/issues/39)

It seems like the template is prescribing a faulty (and inconsistent) way to include ORCIDs. This PR updates the template description accordingly.