### PR TITLE
Add license year workflow

### DIFF
--- a/.github/workflows/update-copyright-year.yml
+++ b/.github/workflows/update-copyright-year.yml
@@ -1,0 +1,24 @@
+name: Update copyright year(s) in license file
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 1 1 *'
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          prTitle: Update the license year
+          prBody: >
+           This PR updates the copyright license for this new year! If you're reading this while you're celebrating, enjoy! Don't worry about this one :blush:
+           ![Happy new year!](https://media.giphy.com/media/HyDfNCZlTn5iU/giphy.gif?cid=ecf05e4777yl7dbo1xfha6bx1z5lrl13uq7biv6rs9dqsyoh&ep=v1_gifs_search&rid=giphy.gif&ct=g)
+      - uses: FantasticFiasco/action-update-license-year@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: | 
+            LICENSE.md
+            LICENSE

--- a/.github/workflows/update-copyright-year.yml
+++ b/.github/workflows/update-copyright-year.yml
@@ -12,13 +12,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          prTitle: Update the license year
-          prBody: >
-           This PR updates the copyright license for this new year! If you're reading this while you're celebrating, enjoy! Don't worry about this one :blush:
-           ![Happy new year!](https://media.giphy.com/media/HyDfNCZlTn5iU/giphy.gif?cid=ecf05e4777yl7dbo1xfha6bx1z5lrl13uq7biv6rs9dqsyoh&ep=v1_gifs_search&rid=giphy.gif&ct=g)
       - uses: FantasticFiasco/action-update-license-year@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: | 
             LICENSE.md
             LICENSE
+          prBody: >
+           This PR updates the copyright license for this new year! If you're reading this while you're celebrating, enjoy! Don't worry about this one :blush:
+           ![Happy new year!](https://media.giphy.com/media/HyDfNCZlTn5iU/giphy.gif?cid=ecf05e4777yl7dbo1xfha6bx1z5lrl13uq7biv6rs9dqsyoh&ep=v1_gifs_search&rid=giphy.gif&ct=g)

--- a/.github/workflows/update-copyright-year.yml
+++ b/.github/workflows/update-copyright-year.yml
@@ -17,7 +17,17 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: | 
             LICENSE.md
-            LICENSE
           prBody: >
            This PR updates the copyright license for this new year! If you're reading this while you're celebrating, enjoy! Don't worry about this one :blush:
+            
            ![Happy new year!](https://media.giphy.com/media/HyDfNCZlTn5iU/giphy.gif?cid=ecf05e4777yl7dbo1xfha6bx1z5lrl13uq7biv6rs9dqsyoh&ep=v1_gifs_search&rid=giphy.gif&ct=g)
+      - uses: FantasticFiasco/action-update-license-year@v2
+        with:
+            token: ${{ secrets.GITHUB_TOKEN }}
+            path: | 
+              LICENSE
+            prBody: >
+             This PR updates the copyright license for this new year! If you're reading this while you're celebrating, enjoy! Don't worry about this one :blush:
+              
+             ![Happy new year!](https://media.giphy.com/media/HyDfNCZlTn5iU/giphy.gif?cid=ecf05e4777yl7dbo1xfha6bx1z5lrl13uq7biv6rs9dqsyoh&ep=v1_gifs_search&rid=giphy.gif&ct=g)
+            transform: (?<=YEAR:\s)(?<from>\d{4})?-?(\d{4})?


### PR DESCRIPTION
This PR adds a workflow to automatically open PRs to update the license year. This helps prevent these from becoming outdated.

Currently it would run at 03.00AM on January 1st ([`0 3 1 1 *`](https://crontab.guru/#0_3_1_1_*)), which we can adjust if we want. The current text would read:

***
   This PR updates the copyright license for this new year! If you're reading this while you're celebrating, enjoy! Don't worry about this one :blush:
           ![Happy new year!](https://media.giphy.com/media/HyDfNCZlTn5iU/giphy.gif?cid=ecf05e4777yl7dbo1xfha6bx1z5lrl13uq7biv6rs9dqsyoh&ep=v1_gifs_search&rid=giphy.gif&ct=g)
***

I am not 100% sure this will run as expected as I don't have everything installed to test this locally beforehand. It is an extension of what we use @libscie, adjusted to handle both LICENSE files present in the template.