### PR TITLE
Isolate citation updates into their own PRs

### DIFF
--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -6,8 +6,6 @@
 on:
   push:
     branches:
-      # This may seem like a no-op but it prevents triggering on tags.
-      # We use '**' rather '*' to accomodate names like 'dev/branch-1'
       - main
     paths:
       - DESCRIPTION

--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -8,7 +8,7 @@ on:
     branches:
       # This may seem like a no-op but it prevents triggering on tags.
       # We use '**' rather '*' to accomodate names like 'dev/branch-1'
-      - '**'
+      - main
     paths:
       - DESCRIPTION
       - inst/CITATION
@@ -16,13 +16,9 @@ on:
   workflow_dispatch:
 
 name: Update CITATION.cff
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update-citation-cff:
@@ -53,12 +49,13 @@ jobs:
           cff_write(keys = mykeys)
 
         shell: Rscript {0}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: Update `CITATION.cff`
+          title: Update `CITATION.cff`
+          body: |
+            This pull request updates the citation file, ensuring all authors are credited and there are no discrepancies.
 
-      - name: Commit results
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add CITATION.cff
-          git commit -m 'Update CITATION.cff' || echo "No changes to commit"
-          git pull --rebase origin ${{ github.ref.name }}
-          git push origin || echo "No changes to commit"
+            Please verify the changes before merging. 
+          branch: update-citation-cff


### PR DESCRIPTION
This PR isolates the action to update the `CITATION.cff`. It is run whenever the relevant files change on the main branch, and creates a pull request if anything changed. 

This was previously discussed in #128 - I tested it as well on a [test repo](https://github.com/chartgerink/testpkg/actions/runs/8077066099).