### PR TITLE
Add vignette building to `.gitignore` and `.Rbuildignore`

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,5 @@
 ^\.Rproj\.user$
 ^CITATION\.cff$
 ^tools$
+^doc$
+^Meta$

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@
 # RStudio files
 .Rproj.user/
 
+# vignette building
+/doc/
+/Meta/
+
 # produced vignettes
 vignettes/*.html
 vignettes/*.pdf


### PR DESCRIPTION
This PR adds `/doc/` and `/Meta/` directories to `.gitignore` and `.Rbuildignore` files. These two directories are produced from `devtools::build_vignettes()`.

- [x] I have read the CONTRIBUTING guidelines
- [ ] A new item has been added to `NEWS.md`
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Checks have been run locally and pass

This PR does not introduce any breaking changes (assuming nobody in the organisation is using these directories as part of their build process or linking to them on GitHub).
