### PR TITLE
Use `actions/checkout@v4` for all workflows

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -22,7 +22,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/update-copyright-year.yml
+++ b/.github/workflows/update-copyright-year.yml
@@ -9,7 +9,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: FantasticFiasco/action-update-license-year@v2


### PR DESCRIPTION
This PR updates the GitHub actions workflow files that were still using `actions/checkout@v3` which triggers a deprecation warning: `Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20...` to use `@v4`.

- [x] I have read the CONTRIBUTING guidelines
- [ ] A new item has been added to `NEWS.md`
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Checks have been run locally and pass

This PR does not contain any breaking changes.