### PR TITLE
Set up dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
cc @jamesmbaazam.

I've been on the fence about this for a while because setting dependabot up puts the burden on individual maintainers to figure out whether they should accept a given dependabot PR.

However:
- the benefits probably outweigh the cost and we can still discuss specific PRs on slack
- official GitHub Actions actions are quite stable and usually don't include breaking changes across versions so the risk is minimal

Related to #9.