### PR TITLE
Add `.github/settings.yml`

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,32 +1,22 @@
 repository:
-  # See https://developer.github.com/v3/repos/#edit for all available settings.
-  private: false
-  has_issues: true
-  has_wiki: false
-  has_discussions: false
-  has_projects: false
-  default_branch: main
-  # Either `true` to allow squash-merging pull requests, or `false` to prevent
-  # squash-merging.
-  allow_squash_merge: true
-  # Either `true` to allow merging pull requests with a merge commit, or `false`
-  # to prevent merging pull requests with merge commits.
-  allow_merge_commit: true
-  # Either `true` to allow rebase-merging pull requests, or `false` to prevent
-  # rebase-merging.
+  # https://probot.github.io/apps/settings/
+  allow_merge_commit: false
   allow_rebase_merge: true
+  allow_squash_merge: true
+  default_branch: main
+  delete_branch_on_merge: true
+  has_discussions: false
+  has_issues: true
+  has_projects: false
+  has_wiki: false
+  private: false
 branches:
   - name: main
     # https://docs.github.com/en/rest/reference/repos#update-branch-protection
     protection:
       required_pull_request_reviews:
-        # The number of approvals required. (1-6)
-        required_approving_review_count: 1
-        # Dismiss approved reviews automatically when a new commit is pushed.
+        required_approving_review_count: 1 # (1-6)
         dismiss_stale_reviews: true
-        # Blocks merge until code owners have reviewed.
-        require_code_owner_reviews: true
-      # Required. Require status checks to pass before merging. Set to null to disable
+        require_code_owner_reviews: false
       required_status_checks:
-        # Required. Require branches to be up to date before merging.
         strict: true

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,32 @@
+repository:
+  # See https://developer.github.com/v3/repos/#edit for all available settings.
+  private: false
+  has_issues: true
+  has_wiki: false
+  has_discussions: false
+  has_projects: false
+  default_branch: main
+  # Either `true` to allow squash-merging pull requests, or `false` to prevent
+  # squash-merging.
+  allow_squash_merge: true
+  # Either `true` to allow merging pull requests with a merge commit, or `false`
+  # to prevent merging pull requests with merge commits.
+  allow_merge_commit: true
+  # Either `true` to allow rebase-merging pull requests, or `false` to prevent
+  # rebase-merging.
+  allow_rebase_merge: true
+branches:
+  - name: main
+    # https://docs.github.com/en/rest/reference/repos#update-branch-protection
+    protection:
+      required_pull_request_reviews:
+        # The number of approvals required. (1-6)
+        required_approving_review_count: 1
+        # Dismiss approved reviews automatically when a new commit is pushed.
+        dismiss_stale_reviews: true
+        # Blocks merge until code owners have reviewed.
+        require_code_owner_reviews: true
+      # Required. Require status checks to pass before merging. Set to null to disable
+      required_status_checks:
+        # Required. Require branches to be up to date before merging.
+        strict: true

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -5,17 +5,17 @@ repository:
   allow_squash_merge: true
   default_branch: main
   delete_branch_on_merge: true
-  has_discussions: false
+  # has_discussions: false
   has_issues: true
-  has_projects: false
-  has_wiki: false
-  private: false
+  # has_projects: false
+  # has_wiki: false
+  # private: false
 branches:
   - name: main
     # https://docs.github.com/en/rest/reference/repos#update-branch-protection
     protection:
       required_pull_request_reviews:
-        required_approving_review_count: 1 # (1-6)
+        required_approving_review_count: 0 # (1-6; optionally 0)
         dismiss_stale_reviews: true
         require_code_owner_reviews: false
       required_status_checks:


### PR DESCRIPTION
We recently installed [the GitHub settings application](https://probot.github.io/apps/settings/) to the `epiverse-trace` organization. This PR adds the relevant `.github/settings.yml` file that will then become part of any future repo's built on the template.

This PR **must** be reviewed, as it also has consequences for this repository that need to be resolved first (see below). The settings are my first best guess as to what we want, based on existing settings from the repositories that I investigated. These are only a departure point for our discussion here 💙 

## Questions

- [x] The settings set wiki + discussions to false by default - this repo has content in both. Depending on whether we want to disable the wiki + discussions by default, how do we deal with the discussion and wiki that currently exist here?