### PR TITLE
Disable some dev linters

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -14,6 +14,8 @@ linters: all_linters(
     ),
     function_argument_linter = NULL,
     indentation_linter = NULL, # unstable as of lintr 3.1.0
+    one_call_pipe_linter = NULL,
+    object_overwrite_linter = NULL,
     # Use minimum R declared in DESCRIPTION or fall back to current R version.
     # Install etdev package from https://github.com/epiverse-trace/etdev
     backport_linter(if (length(x <- etdev::extract_min_r_version())) x else getRversion())


### PR DESCRIPTION
These linters are very opinionated and likely to cause a lot of issues in our current codebases.

I still think the `object_overwrite_linter` is good in principle but probably too opinionated and with a benefit limited to very specific scenarios to be worth enforcing by default (at least at this time).

Based on a chat at the development meeting yesterday, there seemed to be an agreement these are the most controversial linters.