### PR TITLE
Add R CMD check on oldest supported R version

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -54,11 +54,17 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          # Test with the 3 R versions and the 3 platforms from CRAN checks
           - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest,   r: 'release'}
-          - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,  r: 'release'}
+          - {os: ubuntu-latest,  r: 'oldrel-1'}
+          # Older R version we officially support according to the blueprints
+          # https://epiverse-trace.github.io/blueprints/dependencies.html#base-r-support-schedule
+          # If a specific package depends on an older version of R, this can be
+          # tweaked to test the oldest supported version.
+          - {os: ubuntu-latest,  r: 'oldrel-4'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,8 @@ Description: Your package description. It must end with a period (".") and
     include relevant bibliographical references if applicable, using the
     following format: Author et al. (2023) <doi:10.5281/zenodo.6619350>.
 License: MIT + file LICENSE
+Depends: 
+    R (>= 4.0.0)
 Suggests: 
     knitr,
     rmarkdown,


### PR DESCRIPTION
We cannot claim we support a specific R version if we don't test it. By default and per the blueprints, all Epiverse packages should at a minimum support `oldrel-4`. If maintainers of specific packages want to support older version, it's their responsibility to tweak the workflow accordingly.
