### PR TITLE
Only inspect a subset of par() in helper-state

### DIFF
--- a/tests/testthat/helper-state.R
+++ b/tests/testthat/helper-state.R
@@ -5,6 +5,14 @@
 # function, or more conveniently with the `withr` package.
 # We add a test on R >= 4.0.0 because some functions such as
 # `globalCallingHandlers()` did not exist before.
+get_pars_toreset <- function() {
+  pars <- par()
+  # The following params are set and modified automatically by plot() and we:
+  # 1. have no control over them
+  # 2. do not care about resetting them
+  pars <- pars[!names(pars) %in% c("cxy", "usr", "xaxp")]
+}
+
 if (getRversion() >= "4.0.0") {
   testthat::set_state_inspector(function() {
     list(
@@ -16,7 +24,7 @@ if (getRversion() >= "4.0.0") {
       libpaths    = .libPaths(),
       locale      = Sys.getlocale(),
       options     = options(),
-      par         = par(),
+      par         = get_pars_toreset(),
       packages    = .packages(all.available = TRUE),
       sink        = sink.number(),
       timezone    = Sys.timezone(),

--- a/tests/testthat/helper-state.R
+++ b/tests/testthat/helper-state.R
@@ -6,11 +6,11 @@
 # We add a test on R >= 4.0.0 because some functions such as
 # `globalCallingHandlers()` did not exist before.
 get_pars_toreset <- function() {
-  pars <- par()
+  pars <- par(no.readonly = TRUE)
   # The following params are set and modified automatically by plot() and we:
   # 1. have no control over them
   # 2. do not care about resetting them
-  pars <- pars[!names(pars) %in% c("cxy", "usr", "xaxp")]
+  pars <- pars[!names(pars) %in% c("usr", "xaxp")]
 }
 
 if (getRversion() >= "4.0.0") {

--- a/tests/testthat/helper-state.R
+++ b/tests/testthat/helper-state.R
@@ -7,10 +7,11 @@
 # `globalCallingHandlers()` did not exist before.
 get_pars_toreset <- function() {
   pars <- par(no.readonly = TRUE)
-  # The following params are set and modified automatically by plot() and we:
+  # The following params are set and modified automatically by plot(), as
+  # documented in ?plot.window() and we:
   # 1. have no control over them
   # 2. do not care about resetting them
-  pars <- pars[!names(pars) %in% c("usr", "xaxp")]
+  pars <- pars[!names(pars) %in% c("usr", "xaxp", "yaxp")]
 }
 
 if (getRversion() >= "4.0.0") {


### PR DESCRIPTION
This is a proposed fix for #163.
