### PR TITLE
Remove deprecated linter

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -2,7 +2,6 @@ linters: all_linters(
     packages = c("lintr", "etdev"),
     object_name_linter = NULL,
     implicit_integer_linter = NULL,
-    extraction_operator_linter = NULL,
     todo_comment_linter = NULL,
     library_call_linter = NULL,
     undesirable_function_linter(


### PR DESCRIPTION
Fix #171

The `.lintr` needs to be copied in the repositories you maintain to see the effect of this change.
