### PR TITLE
fix: add missing comma in recently added Author@R records

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,11 +15,11 @@ Authors@R: c(
            comment = c(ORCID = "0000-0002-3892-6680")),
     person("Chris", "Hartgerink", , "chris@data.org", role = "ctb",
            comment = c(ORCID = "0000-0003-1050-6809")),
-    person("London School of Hygiene and Tropical Medicine, LSHTM", role = "cph",
+    person("London School of Hygiene and Tropical Medicine, LSHTM", ,  role = "cph",
            comment = c(ROR = "00a0jsq62")),
-    person("Pontificia Universidad Javeriana", role = "cph",
+    person("Pontificia Universidad Javeriana", , role = "cph",
            comment = c(ROR = "03etyjw28")),
-    person("Universidad de los Andes", role = "cph",
+    person("Universidad de los Andes", , role = "cph",
            comment = c(ROR = "02mhbdp94"))
   )
 Description: Your package description. It must end with a period (".") and


### PR DESCRIPTION
- without this, `devtools::check` fails with error message below

Error in read.dcf(path_desc) :
  Found continuation line starting '  ) ...' at begin of record.