### PR TITLE
Gitignore & Rbuildignore files used during release process

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,4 +12,5 @@
 ^doc$
 ^docs$
 ^pkgdown$
+^revdep$
 ^tools$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,5 +1,6 @@
 ^.*\.Rproj$
 ^CITATION\.cff$
+^CRAN-RELEASE$
 ^LICENSE\.md$
 ^Meta$
 ^README\.Rmd$
@@ -9,6 +10,7 @@
 ^\.pre-commit-config\.yaml$
 ^_pkgdown\.yml$
 ^codecov\.yml$
+^cran-comments\.md$
 ^doc$
 ^docs$
 ^pkgdown$

--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,8 @@ rsconnect/
 
 # macOS hidden files
 .DS_Store
-inst/doc
+
+# revdepcheck
+revdep/library
+revdep/data.sqlite
+revdep/checks


### PR DESCRIPTION
Fix #178 
