### PR TITLE
Add lifecycle_linter to lintr CI

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -32,6 +32,7 @@ jobs:
         with:
           extra-packages: |
             any::gh
+            any::lifecycle
             any::lintr
             any::purrr
             any::cyclocomp

--- a/.lintr
+++ b/.lintr
@@ -1,5 +1,5 @@
 linters: all_linters(
-    packages = "lintr",
+    packages = c("lifecycle", "lintr"),
     pipe_consistency_linter(pipe = "|>"),
     object_name_linter = NULL,
     implicit_integer_linter = NULL,


### PR DESCRIPTION
Can be tested in cleanepi for example.

Documentation for the lifecycle_linter: https://lifecycle.r-lib.org/reference/lint_lifecycle.html
